### PR TITLE
Temp fix: Composition error reporting broken

### DIFF
--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1373,10 +1373,6 @@ if (debug) cout <<"Decomposition for Mol " + name << endl;
 	}
 	success=MakeMonList();
 	if (chainlength==1) MolType=monomer;
-
-	cout << success << endl;
-
-
 	return success;
 }
 


### PR DESCRIPTION
The error handling for molecule compositions is broken. This leads to a lot of undefined behavior: segfaults, memory allocation errors, or only an error message, which is then buried because the program continues with faulty calculations.

I have added some comments to point out how / where some things go wrong. Looking at my debugger it seems that the bool success is set to different values in different loops or is not handled at some positions.

As a temporary fix, I included some exception throwing, which is a much more fool-proof way of handling errors. This probably doesn't handle every error, and it should really be fixed by Frans.

Moreover, compositions like [(B)2(A)15(B)2]16 do cause a segfault (Molecule.cpp:921 in this pull request) with no error indications, whereas (A)2[(B)2(A)3(B)2]16(B)5 does not throw an error. Judging from my debugger it seems that the 16 in the last example is ignored and included while handling (B)5, which is read as 16(B)5. So maybe these square brackets are handled incorrectly altogether? I have no idea how they work or should be handled, but the inconsistent error reporting makes it seem that way.