### PR TITLE
Fixing minor bugs in compilation

### DIFF
--- a/src/mesodyn/lattice_accessor.h
+++ b/src/mesodyn/lattice_accessor.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 class Lattice;
 class Lattice_accessor;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -739,7 +739,7 @@ if (debug) cout << "vtk in output " << endl;
 #else
 		fprintf(fp,"%f \n",X[x*JX+y*JY+z]);
 #endif
-	fclose(fp); fflush(fp);
+	fflush(fp); fclose(fp);
 }
 
 void Output::density(){

--- a/src/solve_scf.h
+++ b/src/solve_scf.h
@@ -13,7 +13,7 @@
 #include "variate.h"
 #include "sfnewton.h"
 #include <functional>
-#include <Eigen/Core>
+#include "Eigen/Core"
 #include "LBFGS.h"
 
 //using Eigen::VectorXf;


### PR DESCRIPTION
Dear maintainers,

Thank you for developing and maintaining this software. For an upcoming course that I am co-teaching at TU/e, we are planning to use your package as part of the course material.

While preparing the build environment for our students, I encountered a few minor issues during compilation. I have addressed these in the accompanying pull request and would like to offer the changes in the hope that they are useful to the project.

The proposed fixes are as follows:

1. In `src/mesodyn/lattice_accessor.h`, a `uint8_t` type is used without including `<cstdint>`, which can lead to compilation errors with some toolchains.
2. In `src/solve_scf.h`, Eigen headers were included as `<Eigen/Core>`, which may resolve to a system-wide Eigen installation if present. This pull request switches the include to `"Eigen/Core"` to consistently use the vendored Eigen copy shipped with the project.
3. In `src/output.cpp`, the output buffer is flushed after the file pointer is closed, which may lead to undefined behavior on some systems.

This pull request applies small, targeted changes to address these issues. I hope they are helpful, and I would be happy to adjust the patch if you have any preferences or suggestions.

Thank you for your time and for making this software available.

Kind regards,  
Ivo Filot