### PR TITLE
Fix compilation issues on macOS and improve cross-platform compatibility

### DIFF
--- a/src/mesodyn.cpp
+++ b/src/mesodyn.cpp
@@ -430,7 +430,7 @@ void Mesodyn::initialize_from_file(vector<Lattice_object<Real>>& densities) {
 
 void Mesodyn::set_filename() {
   filename << In[0]->output_info.getOutputPath() << "mesodyn-";
-  filename << time(time_t());
+  filename << time(nullptr);
 }
 
 void Mesodyn::register_output() {

--- a/src/mesodyn/file_writer.cpp
+++ b/src/mesodyn/file_writer.cpp
@@ -61,8 +61,8 @@ void Writable_file::increment_identifier()
     ++m_identifier;
     string new_padded = padded_identifier();
 
-    string dot = "\\.";
-    string s_regex = "(\\_" + old_padded + dot + Writable_file::extension_map[m_filetype] + ')';
+    // Use raw string literal for regex pattern to avoid escaping issues
+    string s_regex = R"((_)" + old_padded + R"(\.)" + Writable_file::extension_map[m_filetype] + R"())";
     std::regex ex(s_regex);
 
     string replacement = "_" + new_padded + "." + Writable_file::extension_map[m_filetype];


### PR DESCRIPTION
## Summary
Fixes two compilation/runtime issues that affect macOS (Apple Clang) but improve cross-platform compatibility overall.

## Changes

### 1. Fix `time()` function call in `mesodyn.cpp`
- Changed `time(time_t())` to `time(nullptr)`
- The `time()` function expects a pointer parameter, not a value
- Old code worked on Linux/Windows due to implicit conversion of `0` to null pointer
- Fails with stricter compilers like Apple Clang 17

### 2. Fix regex pattern in `file_writer.cpp`
- Use C++11 raw string literals `R"(...)"` for regex pattern construction
- Avoids platform-specific escape sequence handling issues
- Fixes runtime `regex_error` crash on macOS when writing mesodyn output
- Makes code more robust and readable

## Testing
- Compiled successfully on macOS (Apple Silicon, Apple Clang 17.0.0)
- Mesodyn simulations complete without crashes
- Changes are standards-compliant and should work on all platforms

## Platforms Affected
- **macOS**: Both issues caused failures
- **Linux/Windows**: Code worked by coincidence, but fixes improve correctness